### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/rawfilepath.cabal
+++ b/rawfilepath.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
     bytestring,
     unix,
-    base >= 4.7 && < 5
+    base >= 4.8 && < 5
   default-language:    Haskell2010
   default-extensions:
     BangPatterns


### PR DESCRIPTION
Currently base-4.7 isn't supported as the compile failure below shows:

```
Configuring component lib from rawfilepath-0.1.1...
Preprocessing library rawfilepath-0.1.1...
[1 of 7] Compiling RawFilePath.Import ( src/RawFilePath/Import.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/RawFilePath/Import.o )
[2 of 7] Compiling System.Process.RawFilePath.Common ( src/System/Process/RawFilePath/Common.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/System/Process/RawFilePath/Common.o )
[3 of 7] Compiling System.Process.RawFilePath.Internal ( src/System/Process/RawFilePath/Internal.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/System/Process/RawFilePath/Internal.o )
[4 of 7] Compiling System.Process.RawFilePath.Posix ( src/System/Process/RawFilePath/Posix.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/System/Process/RawFilePath/Posix.o )
[5 of 7] Compiling System.Process.RawFilePath ( src/System/Process/RawFilePath.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/System/Process/RawFilePath.o )
[6 of 7] Compiling System.RawFilePath ( src/System/RawFilePath.hs, /tmp/matrix-worker/1490092107/dist-newstyle/build/x86_64-linux/ghc-7.8.4/rawfilepath-0.1.1/build/System/RawFilePath.o )

src/System/RawFilePath.hs:94:42:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘*’ (imported from Prelude), ‘**’ (imported from Prelude),
      ‘<’ (imported from Prelude)

src/System/RawFilePath.hs:113:46:
    Not in scope: ‘<*’
    Perhaps you meant one of these:
      ‘*’ (imported from Prelude), ‘**’ (imported from Prelude),
      ‘<’ (imported from Prelude)

src/System/RawFilePath.hs:159:34:
    Not in scope: ‘<$>’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘</>’ (line 263)

src/System/RawFilePath.hs:189:68:
    Not in scope: ‘<$>’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘</>’ (line 263)

src/System/RawFilePath.hs:247:28:
    Not in scope: ‘<$>’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘</>’ (line 263)

src/System/RawFilePath.hs:253:22:
    Not in scope: ‘<$>’
    Perhaps you meant one of these:
      ‘<>’ (imported from Data.Monoid), ‘</>’ (line 263)

```