### PR TITLE
Proposal: Add more generalized version of `proc`

### DIFF
--- a/rawfilepath.cabal
+++ b/rawfilepath.cabal
@@ -36,6 +36,7 @@ library
   include-dirs: cbits
   build-depends:
     bytestring,
+    data-default-class,
     unix,
     base >= 4.7 && < 5
   default-language:    Haskell2010

--- a/rawfilepath.cabal
+++ b/rawfilepath.cabal
@@ -36,7 +36,6 @@ library
   include-dirs: cbits
   build-depends:
     bytestring,
-    data-default-class,
     unix,
     base >= 4.7 && < 5
   default-language:    Haskell2010

--- a/src/RawFilePath/Process.hs
+++ b/src/RawFilePath/Process.hs
@@ -54,6 +54,7 @@ module RawFilePath.Process
     -- $configuring
     , ProcessConf
     , proc
+    , proc'
 
     -- *** Configuring process standard streams
     , StreamType

--- a/src/RawFilePath/Process.hs
+++ b/src/RawFilePath/Process.hs
@@ -65,6 +65,9 @@ module RawFilePath.Process
     , setStdin
     , setStdout
     , setStderr
+    , changeStdin
+    , changeStdout
+    , changeStderr
 
     -- ** Running process
     , Process

--- a/src/RawFilePath/Process/Common.hs
+++ b/src/RawFilePath/Process/Common.hs
@@ -16,6 +16,9 @@ module RawFilePath.Process.Common
     , setStdin
     , setStdout
     , setStderr
+    , changeStdin
+    , changeStdout
+    , changeStderr
 
     , PHANDLE
     , ProcessHandle__(..)
@@ -115,31 +118,58 @@ proc' cmd args = ProcessConf
     , childUser = Nothing
     }
 
--- | Control how the standard input of the process will be initialized.
-setStdin
+-- | Modify how the standard input of the process will be initialized.
+changeStdin
     :: (StreamType newStdin)
     => ProcessConf oldStdin stdout stderr
     -> newStdin
     -> ProcessConf newStdin stdout stderr
-setStdin p newStdin = p { cfgStdin = newStdin }
-infixl 4 `setStdin`
+changeStdin p newStdin = p { cfgStdin = newStdin }
+infixl 4 `changeStdin`
 
--- | Control how the standard output of the process will be initialized.
-setStdout
+-- | Modify how the standard output of the process will be initialized.
+changeStdout
     :: (StreamType newStdout)
     => ProcessConf stdin oldStdout stderr
     -> newStdout
     -> ProcessConf stdin newStdout stderr
-setStdout p newStdout = p { cfgStdout = newStdout }
-infixl 4 `setStdout`
+changeStdout p newStdout = p { cfgStdout = newStdout }
+infixl 4 `changeStdout`
 
--- | Control how the standard error of the process will be initialized.
-setStderr
+-- | Modify how the standard error of the process will be initialized.
+changeStderr
     :: (StreamType newStderr)
     => ProcessConf stdin stdout oldStderr
     -> newStderr
     -> ProcessConf stdin stdout newStderr
-setStderr p newStderr = p { cfgStderr = newStderr }
+changeStderr p newStderr = p { cfgStderr = newStderr }
+infixl 4 `changeStderr`
+
+-- | Control how the standard input of the process will be initialized.
+setStdin
+    :: (StreamType stdin)
+    => ProcessConf Inherit stdout stderr
+    -> stdin
+    -> ProcessConf stdin stdout stderr
+setStdin = changeStdin
+infixl 4 `setStdin`
+
+-- | Control how the standard output of the process will be initialized.
+setStdout
+    :: (StreamType stdout)
+    => ProcessConf stdin Inherit stderr
+    -> stdout
+    -> ProcessConf stdin stdout stderr
+setStdout = changeStdout
+infixl 4 `setStdout`
+
+-- | Control how the standard error of the process will be initialized.
+setStderr
+    :: (StreamType stderr)
+    => ProcessConf stdin stdout Inherit
+    -> stderr
+    -> ProcessConf stdin stdout stderr
+setStderr = changeStderr
 infixl 4 `setStderr`
 
 -- | The process type. The three type variables denote how its standard

--- a/src/RawFilePath/Process/Common.hs
+++ b/src/RawFilePath/Process/Common.hs
@@ -36,7 +36,6 @@ import RawFilePath.Import
 
 import System.Posix.Internals (FD)
 import qualified GHC.IO.FD as FD
-import Data.Default.Class (def, Default)
 
 -- Original declarations
 
@@ -245,6 +244,11 @@ instance StreamType UseHandle where
                 "createProcess" (Just hdl) Nothing
                 `ioeSetErrorString` "handle is not a file descriptor"
     willCreateHandle _ = False
+
+-- | A class of types with default value.
+-- Simply this class is from data-default-class.
+class Default a where
+    def :: a
 
 instance Default CreatePipe where def = CreatePipe
 instance Default Inherit    where def = Inherit


### PR DESCRIPTION
With `proc'`, you can use like this:
```haskell
main = do
    p <- startProcess $ proc' "echo" ["hello"] :: IO (Process NoStream CreatePipe NoStream)
    result <- B.hGetContents (processStdout p)
    _ <- waitForProcess p

    print (result == "hello\n")
```

Or:
```haskell
main = do
    p <- startProcess $ proc' "echo" ["hello"] `setStderr` NoStream `setStdin` NoStream
    result <- B.hGetContents (processStdout p)
    --                          ^ This determines stdout is `CreatePipe`
    _ <- waitForProcess p

    print (result == "hello\n")
```

## Additional changes
- ~~Add `data-default-class` in `build-depends`.~~ - Fixed by cad12af2699e8207b5c0f546b7e9fca0e3754017
- ❗️ Rename old `setStd*` → `changeStd*`.
- ❗️ New `setStd*` assumes previous `ProcessConf`'s stream is `Inherit`.
  
  