### PR TITLE
Fix build with GHC 9.2 (and other small fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /stack.yaml
+dist*

--- a/rawfilepath.cabal
+++ b/rawfilepath.cabal
@@ -13,6 +13,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:
   README.md
+  CHANGELOG.md
 
 library
   hs-source-dirs:      src

--- a/src/RawFilePath/Import.hs
+++ b/src/RawFilePath/Import.hs
@@ -24,6 +24,8 @@ import GHC.IO.Handle.FD as Module hiding
   ( fdToHandle
   , openBinaryFile
   , openFile
+  , withBinaryFile
+  , withFile
   , stderr
   , stdin
   , stdout


### PR DESCRIPTION
I'm not sure exactly why 724ee86114b115190e10380027bdf49f74f96763 is necessary - I can't see anything relevant in the `base` changelog. And given how similar it looks to the changes in https://github.com/xtendo-org/rawfilepath/commit/3b06a3283e77b1b17d6eb415a242ab688c61141e to build on GHC 9.0, perhaps a wider rethink of the way these imports are handled is necessary.

Anyway, these changes get the job done.