### PR TITLE
Support `unix-2.8`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /stack.yaml
+/dist*

--- a/rawfilepath.cabal
+++ b/rawfilepath.cabal
@@ -36,7 +36,7 @@ library
   include-dirs: cbits
   build-depends:
     bytestring,
-    unix,
+    unix >= 2.8,
     base >= 4.7 && < 5
   default-language:    Haskell2010
   default-extensions:

--- a/src/Data/ByteString/RawFilePath.hs
+++ b/src/Data/ByteString/RawFilePath.hs
@@ -49,15 +49,20 @@ withFile :: RawFilePath -> IOMode -> (Handle -> IO r) -> IO r
 withFile path ioMode = bracket (open >>= fdToHandle) hClose
   where
     open = case ioMode of
-        ReadMode -> openFd path ReadOnly Nothing defaultFlags
+        ReadMode -> openFd path ReadOnly $ defaultFlags Nothing
         WriteMode -> createFile path stdFileMode
-        AppendMode -> openFd path WriteOnly (Just stdFileMode) appendFlags
-        ReadWriteMode -> openFd path ReadWrite (Just stdFileMode) defaultFlags
-    defaultFlags = OpenFileFlags
+        AppendMode -> openFd path WriteOnly $ appendFlags $ Just stdFileMode
+        ReadWriteMode -> openFd path ReadWrite $ defaultFlags $ Just stdFileMode
+    defaultFlags creat = OpenFileFlags
         { System.Posix.ByteString.append = False
+        , creat = creat
         , exclusive = False
         , noctty = True
         , nonBlock = False
         , trunc = False
+        , nofollow = False
+        , cloexec = False
+        , directory = False
+        , sync = False
         }
-    appendFlags = defaultFlags { System.Posix.ByteString.append = True }
+    appendFlags creat = (defaultFlags creat) { System.Posix.ByteString.append = True }


### PR DESCRIPTION
You might instead prefer to support a wider range of `unix` versions by using `defaultFileFlags` and some CPP. But even then, this is a start.

Also, old versions of this library will need Hackage revisions to add a `< 2.8` on `unix`.
